### PR TITLE
Fix ArrayIndexOutOfBoundsException with Looting 4

### DIFF
--- a/src/main/java/ipsis/woot/manager/EnumEnchantKey.java
+++ b/src/main/java/ipsis/woot/manager/EnumEnchantKey.java
@@ -17,7 +17,7 @@ public enum EnumEnchantKey {
 
     public static EnumEnchantKey getEnchantKey(int v) {
 
-        if (v < 0 || v > values().length)
+        if (v < 0 || v >= values().length)
             v = 0;
 
         return values()[v];


### PR DESCRIPTION
Fixes an ArrayIndexOutOfBoundsException when player uses a weapon enchanted with Looting IV (ex. using ancient tomes from Quark).