### PR TITLE
1.16.3 Update Prep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,25 +14,21 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 repositories {
-    maven { // TOP
-        name 'tterrag maven'
-        url "http://maven.tterrag.com/"
+    maven {
+        name 'TOP'
+        url "https://maven.tterrag.com/"
     }
     maven {
-        // JEI
-        name = "Progwml6 maven"
-        url = "https://dvs1.progwml6.com/files/maven/"
+        name 'JEI'
+        url "https://dvs1.progwml6.com/files/maven"
     }
-    maven {
-        // JEI fallback
-        name = "ModMaven"
-        url = "https://modmaven.k-4u.nl"
-    }
+    
 
     maven {
-        // Patchouli
-        url 'https://maven.blamejared.com'
+        name 'Patchouli'
+        url "https://maven.blamejared.com"
     }
+
 }
 
 version = "${minecraft_version}-${woot_version}"
@@ -141,16 +137,16 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
     // TOP
-    compileOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-" + top_version + ":api")
-    runtimeOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-" + top_version)
+    compileOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:${top_version}:api")
+    runtimeOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:${top_version}")
 
     // JEI
-    compileOnly fg.deobf("mezz.jei:jei-" + jei_version + ":api")
-    runtimeOnly fg.deobf("mezz.jei:jei-" + jei_version)
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
 
     // Patchouli
-    compileOnly fg.deobf("vazkii.patchouli:Patchouli:" + patchouli_version + ":api")
-    runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:" + patchouli_version)
+    compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
+    runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-woot_version=1.0.0.0
+woot_version=1.1.0.0
 
 # Dependencies
-minecraft_version=1.16.2
+minecraft_version=1.16.3
 mappings_version=20200726-mixed-1.16.1
-forge_version=33.0.22
+forge_version=34.1.17
 
-jei_version=1.16.2:7.1.1.15
-top_version=1.16:1.16-3.0.3-beta-6
+jei_version=7.5.0.43
+top_version=1.16-3.0.4-beta-7
 
-patchouli_version=1.16-42
+patchouli_version=1.16.2-44

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ woot_version=1.1.0.0
 
 # Dependencies
 minecraft_version=1.16.3
-mappings_version=20200726-mixed-1.16.1
+mappings_version=20200916-1.16.2
 forge_version=34.1.17
 
 jei_version=7.5.0.43


### PR DESCRIPTION
when you update to the 1.16.3 version of the patchouli api it will break your code for these three

ExistingFileHelper
exFileHelper
BaseBlockStateProvider

I have some changes i have done to the build.gradle and the gradle.properties which cleaned up some changes that you might want to take a look

because i was going to help you with the MCP mapping but will leave this part for you to do in case you want to rewrite these sections

IF you like i can push the changes i did to your build.gradle and the gradle.properties as it cleans them up a bit and makes future updating them easier

but the changes will break the above three