### PR TITLE
Added JEI recipe catalyst registration for all recipe types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ minecraft {
             // Ansi control
             property 'forge.logging.noansi', 'false'
 
+            // Needed for Patchouli to work in-dev
+            property 'mixin.env.disableRefMap', 'true'
+
             mods {
                 woot {
                     source sourceSets.main
@@ -88,6 +91,9 @@ minecraft {
             // Ansi control
             property 'forge.logging.noansi', 'false'
 
+            // Needed for Patchouli to work in-dev
+            property 'mixin.env.disableRefMap', 'true'
+
             mods {
                 woot {
                     source sourceSets.main
@@ -104,6 +110,9 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
+
+            // Needed for Patchouli to work in-dev
+            property 'mixin.env.disableRefMap', 'true'
 
             args '--mod', 'woot', '--all', '--output', file('src/generated/resources'), '--existing', sourceSets.main.resources.srcDirs[0]
 

--- a/src/main/java/ipsis/woot/compat/jei/WootJeiPlugin.java
+++ b/src/main/java/ipsis/woot/compat/jei/WootJeiPlugin.java
@@ -5,18 +5,22 @@ import ipsis.woot.crafting.*;
 import ipsis.woot.fluilds.FluidSetup;
 import ipsis.woot.modules.anvil.AnvilSetup;
 import ipsis.woot.modules.factory.FactorySetup;
+import ipsis.woot.modules.fluidconvertor.FluidConvertorSetup;
 import ipsis.woot.modules.fluidconvertor.client.FluidConvertorScreen;
 import ipsis.woot.modules.generic.GenericSetup;
+import ipsis.woot.modules.infuser.InfuserSetup;
 import ipsis.woot.modules.infuser.client.InfuserScreen;
 import ipsis.woot.modules.layout.LayoutSetup;
-import ipsis.woot.modules.squeezer.DyeMakeup;
+
 import ipsis.woot.modules.squeezer.SqueezerConfiguration;
+import ipsis.woot.modules.squeezer.SqueezerSetup;
 import ipsis.woot.modules.squeezer.client.DyeSqueezerScreen;
 import ipsis.woot.modules.squeezer.client.EnchantSqueezerScreen;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
 import mezz.jei.api.runtime.IJeiRuntime;
@@ -147,6 +151,15 @@ public class WootJeiPlugin implements IModPlugin {
                 VanillaTypes.FLUID,
                 "jei.woot.puredye"
         );
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addRecipeCatalyst(new ItemStack(AnvilSetup.ANVIL_BLOCK.get()), AnvilRecipeCategory.UID);
+        registration.addRecipeCatalyst(new ItemStack(SqueezerSetup.SQUEEZER_BLOCK.get()), DyeSqueezerRecipeCategory.UID);
+        registration.addRecipeCatalyst(new ItemStack(SqueezerSetup.ENCHANT_SQUEEZER_BLOCK.get()), EnchantSqueezerRecipeCategory.UID);
+        registration.addRecipeCatalyst(new ItemStack(FluidConvertorSetup.FLUID_CONVERTOR_BLOCK.get()), FluidConvertorRecipeCategory.UID);
+        registration.addRecipeCatalyst(new ItemStack(InfuserSetup.INFUSER_BLOCK.get()), InfuserRecipeCategory.UID);
     }
 
     @Override


### PR DESCRIPTION
This allows players to easily find all recipes for a certain machine by searching for that machines uses. This is how JEI shows the crafting table or furnace on the left-side of the interface when viewing a recipe. This is how I will sometimes look for all the recipes a machine can produce. Pictured below is the visual change. This can be tested by right-clicking or pressing "U" while hovering over the machine in JEI. Also fixed launching dev environment crashing when Patchouli is present due to the mixins failing to patch in some instances.

![2021-01-15_19 53 46](https://user-images.githubusercontent.com/5672271/104792450-7a027d00-576c-11eb-9d30-d6ddc24a0901.png)
