### PR TITLE
Added ritual to Blood Magic's guidebook

### DIFF
--- a/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/book.json
+++ b/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/book.json
@@ -1,0 +1,3 @@
+{
+  "extend": "bloodmagic:guide"
+}

--- a/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
+++ b/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
@@ -1,0 +1,40 @@
+{
+  "name": "Ritual of the Martyr",
+  "icon": "woot:yahammer",
+  "category": "bloodmagic:rituals/ritual_list",
+  "pages": [
+    {
+      "type": "multiblock",
+      "name": "Ritual of the Martyr",
+      "multiblock_id": "woot:ritualInfernalMachine",
+      "text": "Use a $(l:bloodmagic:rituals/ritual_diviner#dusk)Ritual Diviner [Dusk]$(/l) for easier construction."
+    },
+    {
+      "type": "bloodmagic:ritual_info",
+      "ritual": "ritualInfernalMachine",
+      "text_overrides": [
+        ["LP", "blood"],
+        ["blood altar", "l:bloodmagic:altar/blood_altar"]
+      ]
+    },
+    {
+      "type": "text",
+      "text": "This ritual draws LP from a fully formed Woot Factory and puts the harvested $(blood)Blood$() into a nearby $(l:bloodmagic:altar/blood_altar)Blood Altar$(). Put a $(l:bloodmagic:altar/soul_network)Blood Orb$() in the Altar, maybe add a few $(l:bloodmagic:altar/blood_rune/sacrifice_rune)Runes of Sacrifice$() for good measure and you'll never have to worry about your LP supplies again... As long as you can supply enough Conatus Fluid."
+    },
+    {
+      "type": "bloodmagic:ritual_data",
+      "ritual": "ritualInfernalMachine",
+      "page_type": "altar",
+      "text": "The Ritual can only link to one altar at a time.",
+      "text_overrides": [
+        ["Blood Altar", "l:bloodmagic:altar/blood_altar"],
+        [" Blood", "blood"]
+      ]
+    },
+    {
+      "type": "bloodmagic:ritual_data",
+      "ritual": "ritualInfernalMachine",
+      "page_type": "damage"
+    }
+  ]
+}

--- a/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
+++ b/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
@@ -6,12 +6,12 @@
     {
       "type": "multiblock",
       "name": "Ritual of the Martyr",
-      "multiblock_id": "woot:ritualInfernalMachine",
+      "multiblock_id": "bloodmagic:ritualinfernalmachine",
       "text": "Use a $(l:bloodmagic:rituals/ritual_diviner#dusk)Ritual Diviner [Dusk]$(/l) for easier construction."
     },
     {
       "type": "bloodmagic:ritual_info",
-      "ritual": "ritualInfernalMachine",
+      "ritual": "ritualinfernalmachine",
       "text_overrides": [
         ["LP", "blood"],
         ["blood altar", "l:bloodmagic:altar/blood_altar"]
@@ -19,11 +19,11 @@
     },
     {
       "type": "text",
-      "text": "This ritual draws LP from a fully formed Woot Factory and puts the harvested $(blood)Blood$() into a nearby $(l:bloodmagic:altar/blood_altar)Blood Altar$(). Put a $(l:bloodmagic:altar/soul_network)Blood Orb$() in the Altar, maybe add a few $(l:bloodmagic:altar/blood_rune/sacrifice_rune)Runes of Sacrifice$() for good measure and you'll never have to worry about your LP supplies again... As long as you can supply enough Conatus Fluid."
+      "text": "This ritual draws LP from a fully formed Woot Factory and puts the harvested $(blood)Blood$() into a nearby $(l:bloodmagic:altar/blood_altar)Blood Altar$(). Put a $(l:bloodmagic:altar/soul_network)Blood Orb$() in the Altar, maybe add a few $(l:bloodmagic:altar/blood_rune/sacrifice_rune)Runes of Sacrifice$() for good measure and you'll never have to worry about your LP supplies again... As long as you can supply enough $(item)Conatus Fluid.$()"
     },
     {
       "type": "bloodmagic:ritual_data",
-      "ritual": "ritualInfernalMachine",
+      "ritual": "ritualinfernalmachine",
       "page_type": "altar",
       "text": "The Ritual can only link to one altar at a time.",
       "text_overrides": [
@@ -33,7 +33,7 @@
     },
     {
       "type": "bloodmagic:ritual_data",
-      "ritual": "ritualInfernalMachine",
+      "ritual": "ritualinfernalmachine",
       "page_type": "heart"
     }
   ]

--- a/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
+++ b/src/main/resources/data/woot/patchouli_books/bloodmagic_extension/en_us/entries/rituals/ritual_list/ritual_martyr.json
@@ -1,6 +1,6 @@
 {
   "name": "Ritual of the Martyr",
-  "icon": "woot:yahammer",
+  "icon": "woot:flayed_1",
   "category": "bloodmagic:rituals/ritual_list",
   "pages": [
     {
@@ -34,7 +34,7 @@
     {
       "type": "bloodmagic:ritual_data",
       "ritual": "ritualInfernalMachine",
-      "page_type": "damage"
+      "page_type": "heart"
     }
   ]
 }


### PR DESCRIPTION
I tried testing this, but just couldn't get the mod to build on my end - it kept freezing up during the 'stitching atlas' part of launching.. Still, this should all work... hopefully.

if I did everything right, then when Woot and Blood Magic are both installed, then the Sanguine Scientum should get a new page under 'Rituals > Ritual List' called 'Ritual of the Martyr'. 

It should make a 3D render of the ritual based on the same ritual definition that WOOT provides to BM to tell it what a valid Martyr ritual looks like, and it should define the ranges for the altar and the Factory Heart using the same information. 

i may have made a namespace mistake with 'ritualInfernalMachine' - not sure what else to call it, feel free to play around and see what works. 

I based the page on the Well of Suffering, as they're broadly similar under the hood, so you can use that for comparison.

If anything doesn't look right, please feel free to let me know here, or swing by the Blood Magic Discord ( https://discord.gg/VtNrGrs ) so we can chat about it. :) 