### PR TITLE
Improve IF compat & fix Rampage+Head Start

### DIFF
--- a/src/main/java/ipsis/woot/compat/industforegoing/IndustrialForegoingPlugin.java
+++ b/src/main/java/ipsis/woot/compat/industforegoing/IndustrialForegoingPlugin.java
@@ -55,6 +55,6 @@ public class IndustrialForegoingPlugin {
         if (ETHER_FLUID == null || world == null || fakeMob == null || !fakeMob.isValid() || !fakeMob.isWither())
             return FluidStack.EMPTY;
 
-        return new FluidStack(ETHER_FLUID, 10);
+        return new FluidStack(ETHER_FLUID, 600);
     }
 }

--- a/src/main/java/ipsis/woot/modules/factory/generators/IndustrialForegoingGenerator.java
+++ b/src/main/java/ipsis/woot/modules/factory/generators/IndustrialForegoingGenerator.java
@@ -1,6 +1,7 @@
 package ipsis.woot.modules.factory.generators;
 
 import ipsis.woot.compat.industforegoing.IndustrialForegoingPlugin;
+import ipsis.woot.modules.factory.FactoryConfiguration;
 import ipsis.woot.modules.factory.FormedSetup;
 import ipsis.woot.modules.factory.perks.Perk;
 import ipsis.woot.util.FakeMob;
@@ -22,38 +23,54 @@ public class IndustrialForegoingGenerator {
             int mobCount = formedSetup.getAllMobParams().get(fakeMob).getMobCount(formedSetup.getAllPerks().containsKey(Perk.Group.MASS), formedSetup.hasMassExotic());
             FluidStack fluidStack = IndustrialForegoingPlugin.getLiquidMeatAmount(fakeMob, world);
             if (!fluidStack.isEmpty()) {
-                fluidStack.setAmount(fluidStack.getAmount() * mobCount);
-                if (generatedFluids.meat.isEmpty())
-                    generatedFluids.meat = fluidStack.copy();
-                else
-                    generatedFluids.meat.setAmount(generatedFluids.meat.getAmount() + fluidStack.getAmount());
+                int perk_tier = formedSetup.getAllPerks().getOrDefault(Perk.Group.SLAUGHTER, 0);
+                if (perk_tier > 0) {
+                    int configVal = FactoryConfiguration.getPerkIntValue(Perk.Group.SLAUGHTER, perk_tier).get();
+                    fluidStack.setAmount((fluidStack.getAmount() * mobCount * configVal) / 100);
+                    if (generatedFluids.meat.isEmpty())
+                        generatedFluids.meat = fluidStack.copy();
+                    else
+                        generatedFluids.meat.setAmount(generatedFluids.meat.getAmount() + fluidStack.getAmount());
+                }
             }
 
             fluidStack = IndustrialForegoingPlugin.getPinkSlimeAmount(fakeMob, world);
             if (!fluidStack.isEmpty()) {
-                fluidStack.setAmount(fluidStack.getAmount() * mobCount);
-                if (generatedFluids.pink.isEmpty())
-                    generatedFluids.pink = fluidStack.copy();
-                else
-                    generatedFluids.pink.setAmount(generatedFluids.pink.getAmount() + fluidStack.getAmount());
+                int perk_tier = formedSetup.getAllPerks().getOrDefault(Perk.Group.SLAUGHTER, 0);
+                if (perk_tier > 0) {
+                    int configVal = FactoryConfiguration.getPerkIntValue(Perk.Group.SLAUGHTER, perk_tier).get();
+                    fluidStack.setAmount((fluidStack.getAmount() * mobCount * configVal) / 100);
+                    if (generatedFluids.pink.isEmpty())
+                        generatedFluids.pink = fluidStack.copy();
+                    else
+                        generatedFluids.pink.setAmount(generatedFluids.pink.getAmount() + fluidStack.getAmount());
+                }
             }
 
             fluidStack = IndustrialForegoingPlugin.getEssenceAmount(fakeMob, world);
             if (!fluidStack.isEmpty()) {
-                fluidStack.setAmount(fluidStack.getAmount() * mobCount);
-                if (generatedFluids.essence.isEmpty())
-                    generatedFluids.essence = fluidStack.copy();
-                else
-                    generatedFluids.essence.setAmount(generatedFluids.essence.getAmount() + fluidStack.getAmount());
+                int perk_tier = formedSetup.getAllPerks().getOrDefault(Perk.Group.CRUSHER, 0);
+                if (perk_tier > 0) {
+                    int configVal = FactoryConfiguration.getPerkIntValue(Perk.Group.CRUSHER, perk_tier).get();
+                    fluidStack.setAmount((fluidStack.getAmount() * mobCount * configVal) / 100);
+                    if (generatedFluids.essence.isEmpty())
+                        generatedFluids.essence = fluidStack.copy();
+                    else
+                        generatedFluids.essence.setAmount(generatedFluids.essence.getAmount() + fluidStack.getAmount());
+                }
             }
 
             fluidStack = IndustrialForegoingPlugin.getEtherAmount(fakeMob, world);
             if (!fluidStack.isEmpty()) {
-                fluidStack.setAmount(fluidStack.getAmount() * mobCount);
-                if (generatedFluids.ether.isEmpty())
-                    generatedFluids.ether = fluidStack.copy();
-                else
-                    generatedFluids.ether.setAmount(generatedFluids.ether.getAmount() + fluidStack.getAmount());
+                int perk_tier = formedSetup.getAllPerks().getOrDefault(Perk.Group.LASER, 0);
+                if (perk_tier > 0) {
+                    int configVal = FactoryConfiguration.getPerkIntValue(Perk.Group.LASER, perk_tier).get();
+                    fluidStack.setAmount((fluidStack.getAmount() * mobCount * configVal) / 100);
+                    if (generatedFluids.ether.isEmpty())
+                        generatedFluids.ether = fluidStack.copy();
+                    else
+                        generatedFluids.ether.setAmount(generatedFluids.ether.getAmount() + fluidStack.getAmount());
+                }
             }
         }
 

--- a/src/main/java/ipsis/woot/modules/factory/generators/LootGeneration.java
+++ b/src/main/java/ipsis/woot/modules/factory/generators/LootGeneration.java
@@ -25,8 +25,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 public class LootGeneration {
 
@@ -151,7 +153,11 @@ public class LootGeneration {
         // Skull gen
         if (setup.getAllPerks().containsKey(Perk.Group.HEADLESS)) {
             List<ItemStack> skulls = new ArrayList<>();
-            setup.getAllMobs().forEach(m -> skulls.add(SKULL_GENERATOR.getSkullDrop(m, setup.getAllMobParams().get(m).getPerkHeadlessValue())));
+            List<FakeMob> countAdjustedMobParams = setup.getAllMobs().stream().map(m -> {
+                int mobCount = setup.getAllMobParams().get(m).getMobCount(setup.getAllPerks().containsKey(Perk.Group.MASS), setup.hasMassExotic());
+                return Collections.nCopies(mobCount, m);
+            }).flatMap(List::stream).collect(Collectors.toList());
+            countAdjustedMobParams.forEach(m -> skulls.add(SKULL_GENERATOR.getSkullDrop(m, setup.getAllMobParams().get(m).getPerkHeadlessValue())));
             StorageHelper.insertItems(skulls, itemHandlers);
         }
 


### PR DESCRIPTION
This is a quick solution to adjust the IF fluid generation to scale based on the level of the perk, fixing #556. It additionally scales skull generation with the number of mobs generated if increased by Rampage, fixing #553.

Finally there is a tweak to the Ether Gas generation amount. In Industrial Foregoing, each cycle of the laser drill over a wither deals only 5 damage, so it would make sense to increase the gas amount to `(the Wither's hp) / (damage per cycle) * (fluid per cycle)` or `300 / 5 * 10 = 600`